### PR TITLE
fix selection of Dyalog versions

### DIFF
--- a/CITA.json5
+++ b/CITA.json5
@@ -7,7 +7,7 @@
 {
     secondstimeout: 900,
     tests: [{
-        "DyalogVersions": "18+",
+        "DyalogVersions": "18-",
         "Test": "./Tests/DTest.dyalogtest",
         "EMail": [{
             "All": "mbaas@dyalog.com"


### PR DESCRIPTION
we don't need to be explicit about 18.2, as that is CITA's minimum anyway